### PR TITLE
[GCHQ] Disabled - new website has no HTTPS.

### DIFF
--- a/src/chrome/content/rules/Government_Communications_Headquarters.xml
+++ b/src/chrome/content/rules/Government_Communications_Headquarters.xml
@@ -2,7 +2,7 @@
      For other UK Government coverage, see GOV.UK.xml.
 -->
 
-<ruleset name="Government Communications Headquarters (GCHQ)">
+<ruleset name="Government Communications Headquarters (GCHQ)" default_off="broken">
     <target host="gchq.gov.uk" />
     <target host="www.gchq.gov.uk" />
 


### PR DESCRIPTION
Disables GCHQ ruleset.
